### PR TITLE
updated box.json file

### DIFF
--- a/box.json
+++ b/box.json
@@ -3,7 +3,7 @@
     "version":"1.0.8.BUILD_NUMBER",
     "author":"Pixl8 Interactive",
     "createPackageDirectory":true,
-    "packageDirectory":"application/extensions/preside-ext-elasticsearch",
+    "directory":"application/extensions",
     "homepage":"",
     "documentation":"",
     "repository":{


### PR DESCRIPTION
packageDirectory should not contain a path but a directory name. the purpose of it is to overwrite the slug - which is the default package directory name. if the package should be installed in a specific location, the directory property is the correct one to use.
